### PR TITLE
Update cmd.js, './output.svg'-> '/output.svg'

### DIFF
--- a/cmd.js
+++ b/cmd.js
@@ -9,7 +9,7 @@ var rgb2hex = require('rgb2hex');
 var image = process.argv[2];
 var output = process.argv[3];
 
-if (!output) output = __dirname + './output.svg';
+if (!output) output = __dirname + '/output.svg';
 var svgStream = fs.createWriteStream(output);
 
 var ProgressBar = require('progress');


### PR DESCRIPTION
Without output file name command, I caught this error.
```
events.js:167
      throw er; // Unhandled 'error' event
      ^

Error: ENOENT: no such file or directory, open '/Users/{userdir}/.anyenv/envs/nodenv/versions/11.0.0/lib/node_modules/png2svg./output.svg'
Emitted 'error' event at:
    at fs.open (internal/fs/streams.js:288:12)
    at FSReqCallback.oncomplete (fs.js:148:20)
```
So I removed just `'.'` in line 12 of cmd.js. Then It works good.